### PR TITLE
Hide anchor links in markdown body

### DIFF
--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -432,6 +432,10 @@ body,
   }
 }
 
+.markdown-body .anchor {
+  display: none;
+}
+
 .markdown-body a:not(.anchor) {
   text-decoration: underline;
   text-underline-offset: 0.08em;


### PR DESCRIPTION
- Hide anchor links on deployed pages