### PR TITLE
docs: fix research node source URLs

### DIFF
--- a/workshop/19-research-driven-training-node.md
+++ b/workshop/19-research-driven-training-node.md
@@ -91,8 +91,8 @@ gh aw compile
   <intent>Teach maintainers how to choose and justify the next workshop node using live gh-aw research.</intent>
   <primary-source>https://raw.githubusercontent.com/github/gh-aw/main/LLMs.txt</primary-source>
   <secondary-sources>
-    <source>https://github.github.com/gh-aw/reference/llms/</source>
-    <source>https://github.github.com/gh-aw/guides/workflow-patterns/</source>
+    <source>https://github.github.com/gh-aw/llms.txt</source>
+    <source>https://github.github.com/gh-aw/patterns/memory-ops/</source>
   </secondary-sources>
 </research-node-metadata>
 -->


### PR DESCRIPTION
Fixes #3176

Replaces both broken secondary-source URLs in the research-driven training workshop metadata with current, validated gh-aw documentation URLs.

## Testing

- `git diff --check`
- Confirmed both replacement URLs return successful HTTP responses

## Worked on by

- nightcityblade
